### PR TITLE
Fix Link to Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd roboflow-100-benchmark
 git submodule update --init --recursive
 ```
 
-You will need an API key. `RF100` can be accessed with any key from Roboflow, head over [our doc](https://docs.roboflow.com/rest-api.') to learn how to get one.
+You will need an API key. `RF100` can be accessed with any key from Roboflow, head over [our doc](https://docs.roboflow.com/rest-api) to learn how to get one.
 
 Then, export the key to your current shell
 


### PR DESCRIPTION
# Description

Minor docs fix to correct a link:
* Before: [our doc](https://docs.roboflow.com/rest-api.')
* After: [our doc](https://docs.roboflow.com/rest-api)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

No need

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ x ] Docs updated? What were the changes:
