### PR TITLE
vehicles-q0x2v: metadata correction

### DIFF
--- a/metadata/datasets_stats.csv
+++ b/metadata/datasets_stats.csv
@@ -67,7 +67,7 @@ soda-bottles,real world,1547,216,486,2249,6.0,0.964,,0.098,1
 truck-movement,real world,740,107,215,1062,7.0,0.786,0.846,0.007,1
 wine-labels,real world,3172,630,841,4643,12.0,0.569,0.632,0.045,1
 digits-t2eg6,real world,2912,367,824,4103,10.0,0.989,0.989,0.003,1
-vehicles-q0x2v,real world,2634,458,966,4058,,0.454,0.464,0.029,1
+vehicles-q0x2v,real world,2634,458,966,4058,12.0,0.454,0.464,0.029,1
 peanuts-sd4kf,real world,268,42,77,387,2.0,0.995,0.997,0.358,1
 printed-circuit-board,real world,548,44,80,672,34.0,0.0907,,0.0,1
 pests-2xlvx,real world,509,55,153,717,28.0,0.136,0.029,0.004,1

--- a/metadata/labels_names.json
+++ b/metadata/labels_names.json
@@ -230,7 +230,7 @@
               "truck-m-": 3672,
               "truck-s-": 1363,
               "truck-xl-": 821},
-  "name": "vv"},
+  "name": "vehicles-q0x2v"},
  {"category": "real world",
   "classes": {"with mold": 14000, "without mold": 5350},
   "name": "peanuts-sd4kf"},


### PR DESCRIPTION
Thank you for providing this great dataset!

While I playing around this dataset, I noticed metadata on vehicles-q0x2v is missing due to typo on labels_names.json.

This commit corrects the data manually.

You can easily check from the original data: https://universe.roboflow.com/roboflow-100/vehicles-q0x2v

# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

By comparing manually. 

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
